### PR TITLE
feat: parallel scan extension for CPU

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -36,6 +36,10 @@ jobs:
         flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
         # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
         flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
+    - name: Build CPP extension
+      run: |
+        python setup.py build
+        find build/ -name "_C*.so" -exec cp {} ./torchlpc/ \;
     - name: Test with pytest
       run: |
         pytest

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ import setuptools
 from torch.utils import cpp_extension
 
 NAME = "torchlpc"
-VERSION = "0.6"
+VERSION = "0.7.dev"
 MAINTAINER = "Chin-Yun Yu"
 EMAIL = "chin-yun.yu@qmul.ac.uk"
 
@@ -27,12 +27,7 @@ setuptools.setup(
         "Operating System :: OS Independent",
     ],
     ext_modules=[
-        cpp_extension.CppExtension("torchlpc", ["torchlpc/csrc/scan_cpu.cpp"])
+        cpp_extension.CppExtension("torchlpc._C", ["torchlpc/csrc/scan_cpu.cpp"])
     ],
     cmdclass={"build_ext": cpp_extension.BuildExtension},
-    # include_dirs=[
-    #     "/Library/Developer/CommandLineTools/usr/lib/clang/16/include",
-    #     "/Library/Developer/CommandLineTools/usr/include",
-    #     "/Library/Developer/CommandLineTools/SDKs/MacOSX15.2.sdk/usr/include",
-    # ],
 )

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,5 @@
 import setuptools
+from torch.utils import cpp_extension
 
 NAME = "torchlpc"
 VERSION = "0.6"
@@ -25,4 +26,13 @@ setuptools.setup(
         "License :: OSI Approved :: MIT License",
         "Operating System :: OS Independent",
     ],
+    ext_modules=[
+        cpp_extension.CppExtension("torchlpc", ["torchlpc/csrc/scan_cpu.cpp"])
+    ],
+    cmdclass={"build_ext": cpp_extension.BuildExtension},
+    # include_dirs=[
+    #     "/Library/Developer/CommandLineTools/usr/lib/clang/16/include",
+    #     "/Library/Developer/CommandLineTools/usr/include",
+    #     "/Library/Developer/CommandLineTools/SDKs/MacOSX15.2.sdk/usr/include",
+    # ],
 )

--- a/tests/test_extension.py
+++ b/tests/test_extension.py
@@ -1,0 +1,36 @@
+import torch
+import torch.nn.functional as F
+import pytest
+from torchlpc.core import lpc_np
+
+
+from .test_grad import create_test_inputs
+
+
+@pytest.mark.parametrize(
+    "samples",
+    [64, 4097],
+)
+@pytest.mark.parametrize(
+    "cmplx",
+    [True, False],
+)
+def test_scan_cpu_equiv(samples: int, cmplx: bool):
+    batch_size = 4
+    x = torch.randn(
+        batch_size, samples, dtype=torch.float32 if not cmplx else torch.complex64
+    )
+    A = torch.rand_like(x) * 1.8 - 0.9
+    zi = torch.randn(batch_size, dtype=x.dtype)
+
+    numba_y = torch.from_numpy(
+        lpc_np(
+            x.cpu().numpy(),
+            -A.cpu().unsqueeze(2).numpy(),
+            zi.cpu().unsqueeze(1).numpy(),
+        )
+    )
+    ext_y = torch.empty_like(x)
+    torch.ops.torchlpc.scan_cpu(x, A, zi, ext_y)
+
+    assert torch.allclose(numba_y, ext_y)

--- a/tests/test_extension.py
+++ b/tests/test_extension.py
@@ -30,7 +30,6 @@ def test_scan_cpu_equiv(samples: int, cmplx: bool):
             zi.cpu().unsqueeze(1).numpy(),
         )
     )
-    ext_y = torch.empty_like(x)
-    torch.ops.torchlpc.scan_cpu(x, A, zi, ext_y)
+    ext_y = torch.ops.torchlpc.scan_cpu(x, A, zi)
 
     assert torch.allclose(numba_y, ext_y)

--- a/tests/test_grad.py
+++ b/tests/test_grad.py
@@ -2,7 +2,7 @@ import pytest
 import torch
 from torch.autograd.gradcheck import gradcheck, gradgradcheck
 from torchlpc.core import LPC
-from torchlpc.recurrence import RecurrenceCUDA
+from torchlpc.recurrence import Recurrence
 
 
 def get_random_biquads(cmplx=False):
@@ -123,21 +123,33 @@ def test_float64_vs_32_cuda():
     "zi_requires_grad",
     [True, False],
 )
-@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
-def test_cuda_parallel_scan(
+@pytest.mark.parametrize(
+    "device",
+    [
+        "cpu",
+        pytest.param(
+            "cuda",
+            marks=pytest.mark.skipif(
+                not torch.cuda.is_available(), reason="CUDA not available"
+            ),
+        ),
+    ],
+)
+def test_parallel_scan(
     x_requires_grad: bool,
     a_requires_grad: bool,
     zi_requires_grad: bool,
+    device: str,
 ):
     batch_size = 2
     samples = 123
-    x = torch.randn(batch_size, samples, dtype=torch.double, device="cuda")
-    A = torch.rand(batch_size, samples, dtype=torch.double, device="cuda") * 2 - 1
-    zi = torch.randn(batch_size, dtype=torch.double, device="cuda")
+    x = torch.randn(batch_size, samples, dtype=torch.double, device=device)
+    A = torch.rand(batch_size, samples, dtype=torch.double, device=device) * 2 - 1
+    zi = torch.randn(batch_size, dtype=torch.double, device=device)
 
     A.requires_grad = a_requires_grad
     x.requires_grad = x_requires_grad
     zi.requires_grad = zi_requires_grad
 
-    assert gradcheck(RecurrenceCUDA.apply, (A, x, zi), check_forward_ad=True)
-    assert gradgradcheck(RecurrenceCUDA.apply, (A, x, zi))
+    assert gradcheck(Recurrence.apply, (A, x, zi), check_forward_ad=True)
+    assert gradgradcheck(Recurrence.apply, (A, x, zi))

--- a/torchlpc/__init__.py
+++ b/torchlpc/__init__.py
@@ -1,6 +1,7 @@
 import torch
 from typing import Optional
 from pathlib import Path
+import warnings
 
 so_files = list(Path(__file__).parent.glob("_C*.so"))
 # assert len(so_files) == 1, f"Expected one _C*.so file, found {len(so_files)}"
@@ -10,6 +11,7 @@ if len(so_files) == 1:
 elif len(so_files) > 1:
     raise ValueError(f"Expected one _C*.so file, found {len(so_files)}")
 else:
+    warnings.warn("No _C*.so file found. Custom extension not loaded.")
     EXTENSION_LOADED = False
 
 from .core import LPC

--- a/torchlpc/__init__.py
+++ b/torchlpc/__init__.py
@@ -1,11 +1,17 @@
 import torch
 from typing import Optional
+from pathlib import Path
 
 from .core import LPC
 from .parallel_scan import WARPSIZE
 from .recurrence import RecurrenceCUDA
 
 __all__ = ["sample_wise_lpc"]
+
+
+so_files = list(Path(__file__).parent.glob("_C*.so"))
+assert len(so_files) == 1, f"Expected one _C*.so file, found {len(so_files)}"
+torch.ops.load_library(so_files[0])
 
 
 def sample_wise_lpc(

--- a/torchlpc/csrc/scan_cpu.cpp
+++ b/torchlpc/csrc/scan_cpu.cpp
@@ -1,19 +1,25 @@
 #include <torch/script.h>
 #include <torch/torch.h>
+
 #include <algorithm>
-#include <vector>
 #include <utility>
+#include <vector>
 
 template <typename scalar_t>
-void scan_cpu(const at::Tensor &input, const at::Tensor &weights, const at::Tensor &initials, const at::Tensor &output)
-{
+void scan_cpu(const at::Tensor &input, const at::Tensor &weights,
+              const at::Tensor &initials, const at::Tensor &output) {
     TORCH_CHECK(input.dim() == 2, "Input must be 2D");
     TORCH_CHECK(initials.dim() == 1, "Initials must be 1D");
-    TORCH_CHECK(weights.sizes() == input.sizes(), "Weights must have the same size as input");
-    TORCH_CHECK(output.sizes() == input.sizes(), "Output must have the same size as input");
-    TORCH_CHECK(initials.size(0) == input.size(0), "The first dimension of initials must be the same as the first dimension of input");
+    TORCH_CHECK(weights.sizes() == input.sizes(),
+                "Weights must have the same size as input");
+    TORCH_CHECK(output.sizes() == input.sizes(),
+                "Output must have the same size as input");
+    TORCH_CHECK(initials.size(0) == input.size(0),
+                "The first dimension of initials must be the same as the first "
+                "dimension of input");
     TORCH_INTERNAL_ASSERT(input.device().is_cpu(), "Input must be on CPU");
-    TORCH_INTERNAL_ASSERT(initials.device().is_cpu(), "Initials must be on CPU");
+    TORCH_INTERNAL_ASSERT(initials.device().is_cpu(),
+                          "Initials must be on CPU");
     TORCH_INTERNAL_ASSERT(weights.device().is_cpu(), "Weights must be on CPU");
     TORCH_INTERNAL_ASSERT(output.device().is_cpu(), "Output must be on CPU");
     TORCH_INTERNAL_ASSERT(output.is_contiguous(), "Output must be contiguous");
@@ -34,46 +40,47 @@ void scan_cpu(const at::Tensor &input, const at::Tensor &weights, const at::Tens
     scalar_t *output_ptr = output.data_ptr<scalar_t>();
 
     std::transform(weights_ptr, weights_ptr + total_size, input_ptr, buffer,
-                   [](const scalar_t &a, const scalar_t &b)
-                   { return std::make_pair(a, b); });
+                   [](const scalar_t &a, const scalar_t &b) {
+                       return std::make_pair(a, b);
+                   });
 
-    at::parallel_for(0, n_batch, 1, [ & ](int64_t start, int64_t end) {
+    at::parallel_for(0, n_batch, 1, [&](int64_t start, int64_t end) {
         for (auto b = start; b < end; b++) {
             std::inclusive_scan(
-                buffer + b * T,
-                buffer + (b + 1) * T,
-                buffer + b * T,
-                [](const std::pair < scalar_t, scalar_t > & a,
-                    const std::pair < scalar_t, scalar_t > & b) {
-                    return std::make_pair(a.first * b.first, a.second * b.first + b.second);
+                buffer + b * T, buffer + (b + 1) * T, buffer + b * T,
+                [](const std::pair<scalar_t, scalar_t> &a,
+                   const std::pair<scalar_t, scalar_t> &b) {
+                    return std::make_pair(a.first * b.first,
+                                          a.second * b.first + b.second);
                 },
-                std::make_pair((scalar_t) 1.0, initials_ptr[b]));
+                std::make_pair((scalar_t)1.0, initials_ptr[b]));
         }
     });
 
-    std::transform(buffer, buffer + total_size, output_ptr, [](const std::pair<scalar_t, scalar_t> &a)
-                   { return a.second; });
+    std::transform(
+        buffer, buffer + total_size, output_ptr,
+        [](const std::pair<scalar_t, scalar_t> &a) { return a.second; });
 }
 
-at::Tensor scan_cpu_wrapper(const at::Tensor &input, const at::Tensor &weights, const at::Tensor &initials)
-{
-    TORCH_CHECK(input.is_floating_point() || input.is_complex(), "Input must be floating point or complex");
-    TORCH_CHECK(initials.scalar_type() == input.scalar_type(), "Initials must have the same scalar type as input");
-    TORCH_CHECK(weights.scalar_type() == input.scalar_type(), "Weights must have the same scalar type as input");
+at::Tensor scan_cpu_wrapper(const at::Tensor &input, const at::Tensor &weights,
+                            const at::Tensor &initials) {
+    TORCH_CHECK(input.is_floating_point() || input.is_complex(),
+                "Input must be floating point or complex");
+    TORCH_CHECK(initials.scalar_type() == input.scalar_type(),
+                "Initials must have the same scalar type as input");
+    TORCH_CHECK(weights.scalar_type() == input.scalar_type(),
+                "Weights must have the same scalar type as input");
 
     auto output = at::empty_like(input);
 
-    AT_DISPATCH_FLOATING_AND_COMPLEX_TYPES(input.scalar_type(), "scan_cpu", [&]
-                                           { scan_cpu<scalar_t>(input, weights, initials, output); });
+    AT_DISPATCH_FLOATING_AND_COMPLEX_TYPES(
+        input.scalar_type(), "scan_cpu",
+        [&] { scan_cpu<scalar_t>(input, weights, initials, output); });
     return output;
 }
 
-TORCH_LIBRARY(torchlpc, m)
-{
+TORCH_LIBRARY(torchlpc, m) {
     m.def("torchlpc::scan_cpu(Tensor a, Tensor b, Tensor c) -> Tensor");
 }
 
-TORCH_LIBRARY_IMPL(torchlpc, CPU, m)
-{
-    m.impl("scan_cpu", &scan_cpu_wrapper);
-}
+TORCH_LIBRARY_IMPL(torchlpc, CPU, m) { m.impl("scan_cpu", &scan_cpu_wrapper); }

--- a/torchlpc/csrc/scan_cpu.cpp
+++ b/torchlpc/csrc/scan_cpu.cpp
@@ -1,72 +1,72 @@
 #include <torch/script.h>
 #include <torch/torch.h>
 #include <algorithm>
-#include <array>
+#include <vector>
 #include <utility>
 
 template <typename scalar_t>
-at::Tensor scan_cpu(const at::Tensor &input, const at::Tensor &initials, const at::Tensor &weights)
+void scan_cpu(const at::Tensor &input, const at::Tensor &weights, const at::Tensor &initials, at::Tensor &output)
 {
     TORCH_CHECK(input.dim() == 2, "Input must be 2D");
     TORCH_CHECK(initials.dim() == 1, "Initials must be 1D");
     TORCH_CHECK(weights.sizes() == input.sizes(), "Weights must have the same size as input");
+    TORCH_CHECK(output.sizes() == input.sizes(), "Output must have the same size as input");
     TORCH_CHECK(initials.size(0) == input.size(0), "The first dimension of initials must be the same as the first dimension of input");
-    // TORCH_INTERNAL_ASSERT(input.scalar_type() == at::kFloat, "Input must be float");
-    // TORCH_INTERNAL_ASSERT(initials.scalar_type() == at::kFloat, "Initials must be float");
-    // TORCH_INTERNAL_ASSERT(weights.scalar_type() == at::kFloat, "Weights must be float");
     TORCH_INTERNAL_ASSERT(input.device().is_cpu(), "Input must be on CPU");
     TORCH_INTERNAL_ASSERT(initials.device().is_cpu(), "Initials must be on CPU");
     TORCH_INTERNAL_ASSERT(weights.device().is_cpu(), "Weights must be on CPU");
+    TORCH_INTERNAL_ASSERT(output.device().is_cpu(), "Output must be on CPU");
     TORCH_INTERNAL_ASSERT(input.is_contiguous(), "Input must be contiguous");
-    TORCH_INTERNAL_ASSERT(initials.is_contiguous(), "Initials must be contiguous");
     TORCH_INTERNAL_ASSERT(weights.is_contiguous(), "Weights must be contiguous");
+    TORCH_INTERNAL_ASSERT(output.is_contiguous(), "Output must be contiguous");
 
     auto n_batch = input.size(0);
     auto T = input.size(1);
     auto total_size = input.numel();
 
-    std::array<std::pair<scalar_t, scalar_t>, total_size> buffer;
-    at::Tensor output = at::empty_like(input);
+    std::pair<scalar_t, scalar_t> buffer[total_size];
 
     const scalar_t *input_ptr = input.data_ptr<scalar_t>();
     const scalar_t *initials_ptr = initials.data_ptr<scalar_t>();
     const scalar_t *weights_ptr = weights.data_ptr<scalar_t>();
     scalar_t *output_ptr = output.data_ptr<scalar_t>();
 
-    std::transform(weights_ptr, weights_ptr + total_size, input_ptr, buffer.begin(), std::make_pair<scalar_t, scalar_t>);
+    std::transform(weights_ptr, weights_ptr + total_size, input_ptr, buffer,
+                   [](const scalar_t &a, const scalar_t &b)
+                   { return std::make_pair(a, b); });
 
-    at::parallel_for(0, n_batch, 1, [buffer, T, initials_ptr](int64_t start, int64_t end)
+    at::parallel_for(0, n_batch, 1, [&](int64_t start, int64_t end)
                      {
         for (auto b = start; b < end; b++)
         {
             std::inclusive_scan(
-            buffer.begin() + b * T, 
-            buffer.begin() + (b + 1) * T, 
-            buffer.begin() + b * T, 
-            [](std::pair<scalar_t, scalar_t> &a, const std::pair<scalar_t, scalar_t> &b) {
-                return std::make_pair(a.first * b.first, a.second * b.first + b.second);
-            }, std::make_pair(1.0, initials_ptr[b]));
+                buffer + b * T,
+                buffer + (b + 1) * T,
+                buffer + b * T,
+                [](const std::pair<scalar_t, scalar_t> &a, const std::pair<scalar_t, scalar_t> &b) {
+                    return std::make_pair(a.first * b.first, a.second * b.first + b.second);
+                },
+                std::make_pair((scalar_t)1.0, initials_ptr[b]));
         } });
 
-    std::transform(buffer.begin(), buffer.end(), output_ptr, [](const std::pair<scalar_t, scalar_t> &a)
+    std::transform(buffer, buffer + total_size, output_ptr, [](const std::pair<scalar_t, scalar_t> &a)
                    { return a.second; });
-
-    return output;
 }
 
-at::Tensor scan_cpu_wrapper(const at::Tensor &input, const at::Tensor &initials, const at::Tensor &weights)
+void scan_cpu_wrapper(const at::Tensor &input, const at::Tensor &weights, const at::Tensor &initials, at::Tensor &output)
 {
     TORCH_CHECK(input.is_floating_point() || input.is_complex(), "Input must be floating point or complex");
-    TORCH_CHECK(initials.is_floating_point() || initials.is_complex(), "Initials must be floating point or complex");
-    TORCH_CHECK(weights.is_floating_point() || weights.is_complex(), "Weights must be floating point or complex");
+    TORCH_CHECK(initials.scalar_type() == input.scalar_type(), "Initials must have the same scalar type as input");
+    TORCH_CHECK(weights.scalar_type() == input.scalar_type(), "Weights must have the same scalar type as input");
+    TORCH_CHECK(output.scalar_type() == input.scalar_type(), "Output must have the same scalar type as input");
 
     AT_DISPATCH_FLOATING_AND_COMPLEX_TYPES(input.scalar_type(), "scan_cpu", [&]
-                                           { return scan_cpu<scalar_t>(input, initials, weights); });
+                                           { scan_cpu<scalar_t>(input, weights, initials, output); });
 }
 
 TORCH_LIBRARY(torchlpc, m)
 {
-    m.def("torchlpc::scan_cpu(Tensor input, Tensor initials, Tensor weights) -> Tensor");
+    m.def("torchlpc::scan_cpu(Tensor a, Tensor b, Tensor c, Tensor(a!) out) -> ()");
 }
 
 TORCH_LIBRARY_IMPL(torchlpc, CPU, m)

--- a/torchlpc/csrc/scan_cpu.cpp
+++ b/torchlpc/csrc/scan_cpu.cpp
@@ -16,9 +16,13 @@ void scan_cpu(const at::Tensor &input, const at::Tensor &weights, const at::Tens
     TORCH_INTERNAL_ASSERT(initials.device().is_cpu(), "Initials must be on CPU");
     TORCH_INTERNAL_ASSERT(weights.device().is_cpu(), "Weights must be on CPU");
     TORCH_INTERNAL_ASSERT(output.device().is_cpu(), "Output must be on CPU");
-    TORCH_INTERNAL_ASSERT(input.is_contiguous(), "Input must be contiguous");
-    TORCH_INTERNAL_ASSERT(weights.is_contiguous(), "Weights must be contiguous");
+    // TORCH_INTERNAL_ASSERT(input.is_contiguous(), "Input must be contiguous");
+    // TORCH_INTERNAL_ASSERT(weights.is_contiguous(), "Weights must be contiguous");
     TORCH_INTERNAL_ASSERT(output.is_contiguous(), "Output must be contiguous");
+
+    auto input_contiguous = input.contiguous();
+    auto weights_contiguous = weights.contiguous();
+    auto initials_contiguous = initials.contiguous();
 
     auto n_batch = input.size(0);
     auto T = input.size(1);
@@ -26,9 +30,9 @@ void scan_cpu(const at::Tensor &input, const at::Tensor &weights, const at::Tens
 
     std::pair<scalar_t, scalar_t> buffer[total_size];
 
-    const scalar_t *input_ptr = input.data_ptr<scalar_t>();
-    const scalar_t *initials_ptr = initials.data_ptr<scalar_t>();
-    const scalar_t *weights_ptr = weights.data_ptr<scalar_t>();
+    const scalar_t *input_ptr = input_contiguous.data_ptr<scalar_t>();
+    const scalar_t *initials_ptr = initials_contiguous.data_ptr<scalar_t>();
+    const scalar_t *weights_ptr = weights_contiguous.data_ptr<scalar_t>();
     scalar_t *output_ptr = output.data_ptr<scalar_t>();
 
     std::transform(weights_ptr, weights_ptr + total_size, input_ptr, buffer,

--- a/torchlpc/csrc/scan_cpu.cpp
+++ b/torchlpc/csrc/scan_cpu.cpp
@@ -1,0 +1,75 @@
+#include <torch/script.h>
+#include <torch/torch.h>
+#include <algorithm>
+#include <array>
+#include <utility>
+
+template <typename scalar_t>
+at::Tensor scan_cpu(const at::Tensor &input, const at::Tensor &initials, const at::Tensor &weights)
+{
+    TORCH_CHECK(input.dim() == 2, "Input must be 2D");
+    TORCH_CHECK(initials.dim() == 1, "Initials must be 1D");
+    TORCH_CHECK(weights.sizes() == input.sizes(), "Weights must have the same size as input");
+    TORCH_CHECK(initials.size(0) == input.size(0), "The first dimension of initials must be the same as the first dimension of input");
+    // TORCH_INTERNAL_ASSERT(input.scalar_type() == at::kFloat, "Input must be float");
+    // TORCH_INTERNAL_ASSERT(initials.scalar_type() == at::kFloat, "Initials must be float");
+    // TORCH_INTERNAL_ASSERT(weights.scalar_type() == at::kFloat, "Weights must be float");
+    TORCH_INTERNAL_ASSERT(input.device().is_cpu(), "Input must be on CPU");
+    TORCH_INTERNAL_ASSERT(initials.device().is_cpu(), "Initials must be on CPU");
+    TORCH_INTERNAL_ASSERT(weights.device().is_cpu(), "Weights must be on CPU");
+    TORCH_INTERNAL_ASSERT(input.is_contiguous(), "Input must be contiguous");
+    TORCH_INTERNAL_ASSERT(initials.is_contiguous(), "Initials must be contiguous");
+    TORCH_INTERNAL_ASSERT(weights.is_contiguous(), "Weights must be contiguous");
+
+    auto n_batch = input.size(0);
+    auto T = input.size(1);
+    auto total_size = input.numel();
+
+    std::array<std::pair<scalar_t, scalar_t>, total_size> buffer;
+    at::Tensor output = at::empty_like(input);
+
+    const scalar_t *input_ptr = input.data_ptr<scalar_t>();
+    const scalar_t *initials_ptr = initials.data_ptr<scalar_t>();
+    const scalar_t *weights_ptr = weights.data_ptr<scalar_t>();
+    scalar_t *output_ptr = output.data_ptr<scalar_t>();
+
+    std::transform(weights_ptr, weights_ptr + total_size, input_ptr, buffer.begin(), std::make_pair<scalar_t, scalar_t>);
+
+    at::parallel_for(0, n_batch, 1, [buffer, T, initials_ptr](int64_t start, int64_t end)
+                     {
+        for (auto b = start; b < end; b++)
+        {
+            std::inclusive_scan(
+            buffer.begin() + b * T, 
+            buffer.begin() + (b + 1) * T, 
+            buffer.begin() + b * T, 
+            [](std::pair<scalar_t, scalar_t> &a, const std::pair<scalar_t, scalar_t> &b) {
+                return std::make_pair(a.first * b.first, a.second * b.first + b.second);
+            }, std::make_pair(1.0, initials_ptr[b]));
+        } });
+
+    std::transform(buffer.begin(), buffer.end(), output_ptr, [](const std::pair<scalar_t, scalar_t> &a)
+                   { return a.second; });
+
+    return output;
+}
+
+at::Tensor scan_cpu_wrapper(const at::Tensor &input, const at::Tensor &initials, const at::Tensor &weights)
+{
+    TORCH_CHECK(input.is_floating_point() || input.is_complex(), "Input must be floating point or complex");
+    TORCH_CHECK(initials.is_floating_point() || initials.is_complex(), "Initials must be floating point or complex");
+    TORCH_CHECK(weights.is_floating_point() || weights.is_complex(), "Weights must be floating point or complex");
+
+    AT_DISPATCH_FLOATING_AND_COMPLEX_TYPES(input.scalar_type(), "scan_cpu", [&]
+                                           { return scan_cpu<scalar_t>(input, initials, weights); });
+}
+
+TORCH_LIBRARY(torchlpc, m)
+{
+    m.def("torchlpc::scan_cpu(Tensor input, Tensor initials, Tensor weights) -> Tensor", &scan_cpu<float>);
+}
+
+TORCH_LIBRARY_IMPL(torchlpc, CPU, m)
+{
+    m.impl("scan_cpu", &scan_cpu_wrapper);
+}

--- a/torchlpc/csrc/scan_cpu.cpp
+++ b/torchlpc/csrc/scan_cpu.cpp
@@ -66,7 +66,7 @@ at::Tensor scan_cpu_wrapper(const at::Tensor &input, const at::Tensor &initials,
 
 TORCH_LIBRARY(torchlpc, m)
 {
-    m.def("torchlpc::scan_cpu(Tensor input, Tensor initials, Tensor weights) -> Tensor", &scan_cpu<float>);
+    m.def("torchlpc::scan_cpu(Tensor input, Tensor initials, Tensor weights) -> Tensor");
 }
 
 TORCH_LIBRARY_IMPL(torchlpc, CPU, m)

--- a/torchlpc/csrc/scan_cpu.cpp
+++ b/torchlpc/csrc/scan_cpu.cpp
@@ -53,20 +53,23 @@ void scan_cpu(const at::Tensor &input, const at::Tensor &weights, const at::Tens
                    { return a.second; });
 }
 
-void scan_cpu_wrapper(const at::Tensor &input, const at::Tensor &weights, const at::Tensor &initials, at::Tensor &output)
+at::Tensor scan_cpu_wrapper(const at::Tensor &input, const at::Tensor &weights, const at::Tensor &initials)
 {
     TORCH_CHECK(input.is_floating_point() || input.is_complex(), "Input must be floating point or complex");
     TORCH_CHECK(initials.scalar_type() == input.scalar_type(), "Initials must have the same scalar type as input");
     TORCH_CHECK(weights.scalar_type() == input.scalar_type(), "Weights must have the same scalar type as input");
-    TORCH_CHECK(output.scalar_type() == input.scalar_type(), "Output must have the same scalar type as input");
+    // TORCH_CHECK(output.scalar_type() == input.scalar_type(), "Output must have the same scalar type as input");
+
+    auto output = at::empty_like(input);
 
     AT_DISPATCH_FLOATING_AND_COMPLEX_TYPES(input.scalar_type(), "scan_cpu", [&]
                                            { scan_cpu<scalar_t>(input, weights, initials, output); });
+    return output;
 }
 
 TORCH_LIBRARY(torchlpc, m)
 {
-    m.def("torchlpc::scan_cpu(Tensor a, Tensor b, Tensor c, Tensor(a!) out) -> ()");
+    m.def("torchlpc::scan_cpu(Tensor a, Tensor b, Tensor c) -> Tensor");
 }
 
 TORCH_LIBRARY_IMPL(torchlpc, CPU, m)

--- a/torchlpc/recurrence.py
+++ b/torchlpc/recurrence.py
@@ -6,6 +6,7 @@ from typing import Tuple, Optional, Any, List
 
 from .parallel_scan import compute_linear_recurrence, WARPSIZE
 from .core import lpc_cuda, lpc_np
+from . import EXTENSION_LOADED
 
 
 class Recurrence(Function):
@@ -32,7 +33,7 @@ class Recurrence(Function):
         else:
             num_threads = torch.get_num_threads()
             # This is just a rough estimation of the computational cost
-            if min(n_dims, num_threads) < num_threads / 3:
+            if EXTENSION_LOADED and min(n_dims, num_threads) < num_threads / 3:
                 out = torch.ops.torchlpc.scan_cpu(impulse, decay, initial_state)
             else:
                 out = torch.from_numpy(

--- a/torchlpc/recurrence.py
+++ b/torchlpc/recurrence.py
@@ -4,10 +4,11 @@ from torch.autograd import Function
 from numba import cuda
 from typing import Tuple, Optional, Any, List
 
-from .parallel_scan import compute_linear_recurrence
+from .parallel_scan import compute_linear_recurrence, WARPSIZE
+from .core import lpc_cuda, lpc_np
 
 
-class RecurrenceCUDA(Function):
+class Recurrence(Function):
     @staticmethod
     def forward(
         decay: torch.Tensor,
@@ -15,15 +16,32 @@ class RecurrenceCUDA(Function):
         initial_state: torch.Tensor,
     ) -> torch.Tensor:
         n_dims, n_steps = decay.shape
-        out = torch.empty_like(impulse)
-        compute_linear_recurrence(
-            cuda.as_cuda_array(decay.detach()),
-            cuda.as_cuda_array(impulse.detach()),
-            cuda.as_cuda_array(initial_state.detach()),
-            cuda.as_cuda_array(out),
-            n_dims,
-            n_steps,
-        )
+        if decay.is_cuda:
+            if n_dims * WARPSIZE < n_steps:
+                out = torch.empty_like(impulse)
+                compute_linear_recurrence(
+                    cuda.as_cuda_array(decay.detach()),
+                    cuda.as_cuda_array(impulse.detach()),
+                    cuda.as_cuda_array(initial_state.detach()),
+                    cuda.as_cuda_array(out),
+                    n_dims,
+                    n_steps,
+                )
+            else:
+                out = lpc_cuda(impulse, -decay.unsqueeze(2), initial_state.unsqueeze(1))
+        else:
+            num_threads = torch.get_num_threads()
+            # This is just a rough estimation of the computational cost
+            if min(n_dims, num_threads) < num_threads / 3:
+                out = torch.ops.torchlpc.scan_cpu(impulse, decay, initial_state)
+            else:
+                out = torch.from_numpy(
+                    lpc_np(
+                        impulse.detach().numpy(),
+                        -decay.unsqueeze(2).detach().numpy(),
+                        initial_state.unsqueeze(1).detach().numpy(),
+                    )
+                )
         return out
 
     @staticmethod
@@ -48,7 +66,7 @@ class RecurrenceCUDA(Function):
             padded_decay = padded_decay[:, 1:]
 
         init = padded_grad_out.new_zeros(n_dims)
-        flipped_grad_impulse = RecurrenceCUDA.apply(
+        flipped_grad_impulse = Recurrence.apply(
             padded_decay.flip(1).conj_physical(),
             padded_grad_out.flip(1),
             init,
@@ -91,7 +109,7 @@ class RecurrenceCUDA(Function):
             fwd_decay = concat_out * grad_decay
             fwd_impulse = fwd_impulse + fwd_decay
 
-        return RecurrenceCUDA.apply(decay, fwd_impulse, fwd_initial_state)
+        return Recurrence.apply(decay, fwd_impulse, fwd_initial_state)
 
     @staticmethod
     def vmap(info, in_dims, *args):
@@ -107,5 +125,8 @@ class RecurrenceCUDA(Function):
             )
         )
 
-        out = RecurrenceCUDA.apply(decay, impulse, initial_state)
+        out = Recurrence.apply(decay, impulse, initial_state)
         return out.reshape(info.batch_size, -1, *out.shape[1:]), 0
+
+
+RecurrenceCUDA = Recurrence


### PR DESCRIPTION
Accelerate first-order filter on CPU for small batch sizes. 
This PR serves as a first step to gradually remove `numba` code and use the native cpp bindings by PyTorch. #10 could be merged after this PR.
The empirical benchmark shows the extension is faster when batch size < 2.

I plan to keep the `main` for development purposes, so the version will always be `*.dev`. I will make a separate branch for the stable version.